### PR TITLE
Scripts used at runtime should be final outputs.

### DIFF
--- a/.github/workflows/validate-wdl.yml
+++ b/.github/workflows/validate-wdl.yml
@@ -1,0 +1,39 @@
+name: Validate WDL workflow and task definitions
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # Runs a set of commands using the runners shell
+      - name: Validate WDL
+        run: |
+          set -o xtrace
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+        
+          sudo apt-get install shellcheck
+          pip install miniwdl
+        
+          for WDL_FILE in $(find . -type f -name "*.wdl"); do
+              miniwdl check ${WDL_FILE}
+          done

--- a/embedding_creation_script.wdl
+++ b/embedding_creation_script.wdl
@@ -120,8 +120,9 @@ workflow EmbeddingCreation {
     }
 
     output {
+        File shardingScriptUsed = determineShards.executedScript
+        File embeddingCreationScriptUsed = runEmbeddingCreationScript.executedScript[0]
         String outputDirectory = delocalizeEmbeddingOutputs.output_directory[0]
-        Array[File] tarOutputs = runEmbeddingCreationScript.tarOutputs
         Array[File] dataWarningsLog = runEmbeddingCreationScript.dataWarningsLog
     }
 }


### PR DESCRIPTION
Also remove tarOutputs from final outputs so that 'delete intermediate results' can clear them when the workflow completes successfully.