### PR TITLE
Update workflow to use the public Docker image.

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -3,3 +3,5 @@ workflows:
   - subclass: WDL
     primaryDescriptorPath: /embedding_creation_script.wdl
     topic: Method to compute per-cell embeddings for all JUMP-CP data.
+    testParameterFiles:
+    - /single_plate_example_inputs.json

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -1,5 +1,6 @@
 version: 1.2
 workflows:
   - subclass: WDL
-    primaryDescriptorPath: embedding_creation_script.wdl
+    primaryDescriptorPath: /embedding_creation_script.wdl
     name: EmbeddingCreation
+    topic: A short descrption of this workflow

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -2,4 +2,4 @@ version: 1.2
 workflows:
   - subclass: WDL
     primaryDescriptorPath: /embedding_creation_script.wdl
-    topic: A short descrption of this workflow
+    topic: Method to compute per-cell embeddings for all JUMP-CP data.

--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -2,5 +2,4 @@ version: 1.2
 workflows:
   - subclass: WDL
     primaryDescriptorPath: /embedding_creation_script.wdl
-    name: EmbeddingCreation
     topic: A short descrption of this workflow

--- a/embedding_creation_script.wdl
+++ b/embedding_creation_script.wdl
@@ -36,6 +36,7 @@ workflow EmbeddingCreation {
         Int embeddingCreationCPU = 8
         Int embeddingCreationMemoryGB = 30
         Int embeddingCreationDiskGB = 10
+        Int embeddingCreationBootDiskGB = 15
         Int embeddingCreationMaxRetries = 1
         Int embeddingCreationPreemptibleAttempts = 2
         String embeddingCreationGPUType = "nvidia-tesla-t4"
@@ -53,7 +54,7 @@ workflow EmbeddingCreation {
             loadDataWithIllum = loadDataWithIllum,
             modulus = modulus,
             dockerImage = embeddingCreationDockerImage,
-            diskGB = embeddingCreationDiskGB
+            bootDiskGB = embeddingCreationBootDiskGB
     }
 
     # Run embedding creation scattered by shards of multiple wells.
@@ -73,6 +74,7 @@ workflow EmbeddingCreation {
                 cpu = embeddingCreationCPU,
                 memoryGB = embeddingCreationMemoryGB,
                 diskGB = embeddingCreationDiskGB,
+                bootDiskGB = embeddingCreationBootDiskGB,
                 maxRetries = embeddingCreationMaxRetries,
                 preemptibleAttempts = embeddingCreationPreemptibleAttempts,
                 gpuType = embeddingCreationGPUType,
@@ -105,7 +107,7 @@ task determineShards {
 
         # Docker image
         String dockerImage = 'ghcr.io/deflaux/embedding_creation:20240502_203214'
-        Int diskGB = 10
+        Int bootDiskGB = 15
     }
 
     String outputFilename = 'shards_metadata.txt'
@@ -132,7 +134,7 @@ task determineShards {
 
     runtime {
         docker: dockerImage
-        disks: 'local-disk ' + diskGB + ' SSD'
+        bootDiskSizeGb: bootDiskGB
         maxRetries: 1
         preemptible: 2
     }
@@ -157,6 +159,7 @@ task runEmbeddingCreationScript {
         Int cpu = 8
         Int memoryGB = 30
         Int diskGB = 10
+        Int bootDiskGB = 15
         Int maxRetries = 1
         Int preemptibleAttempts = 2
         String gpuType = 'nvidia-tesla-t4'
@@ -208,6 +211,7 @@ task runEmbeddingCreationScript {
         docker: dockerImage
         memory: memoryGB + ' GB'
         disks: 'local-disk ' + diskGB + ' SSD'
+        bootDiskSizeGb: bootDiskGB
         maxRetries: maxRetries
         preemptible: preemptibleAttempts
         cpu: cpu

--- a/embedding_creation_script.wdl
+++ b/embedding_creation_script.wdl
@@ -52,7 +52,8 @@ workflow EmbeddingCreation {
         input:
             loadDataWithIllum = loadDataWithIllum,
             modulus = modulus,
-            dockerImage = embeddingCreationDockerImage
+            dockerImage = embeddingCreationDockerImage,
+            diskGB = embeddingCreationDiskGB
     }
 
     # Run embedding creation scattered by shards of multiple wells.
@@ -104,6 +105,7 @@ task determineShards {
 
         # Docker image
         String dockerImage = 'ghcr.io/deflaux/embedding_creation:20240502_203214'
+        Int diskGB = 10
     }
 
     String outputFilename = 'shards_metadata.txt'
@@ -130,6 +132,7 @@ task determineShards {
 
     runtime {
         docker: dockerImage
+        disks: 'local-disk ' + diskGB + ' SSD'
         maxRetries: 1
         preemptible: 2
     }

--- a/embedding_creation_script.wdl
+++ b/embedding_creation_script.wdl
@@ -32,7 +32,7 @@ workflow EmbeddingCreation {
         Int tfHubModelInputImageHeight
         Int tfHubModelInputImageWidth
         Int tfHubModelOutputEmbSize
-        String embeddingCreationDockerImage = 'PUBLIC_DOCKER_IMAGE_WILL_GO_HERE'
+        String embeddingCreationDockerImage = 'ghcr.io/deflaux/embedding_creation:20240502_203214'
         Int embeddingCreationCPU = 8
         Int embeddingCreationMemoryGB = 30
         Int embeddingCreationDiskGB = 10
@@ -103,7 +103,7 @@ task determineShards {
         Int modulus = 24
 
         # Docker image
-        String dockerImage = 'PUBLIC_DOCKER_IMAGE_GOES_HERE'
+        String dockerImage = 'ghcr.io/deflaux/embedding_creation:20240502_203214'
     }
 
     String outputFilename = 'shards_metadata.txt'
@@ -150,7 +150,7 @@ task runEmbeddingCreationScript {
         Int tfHubModelInputImageWidth
         Int tfHubModelOutputEmbSize
 
-        String dockerImage = 'PUBLIC_DOCKER_IMAGE_GOES_HERE'
+        String dockerImage = 'ghcr.io/deflaux/embedding_creation:20240502_203214'
         Int cpu = 8
         Int memoryGB = 30
         Int diskGB = 10

--- a/embedding_creation_script.wdl
+++ b/embedding_creation_script.wdl
@@ -32,7 +32,7 @@ workflow EmbeddingCreation {
         Int tfHubModelInputImageHeight
         Int tfHubModelInputImageWidth
         Int tfHubModelOutputEmbSize
-        String embeddingCreationDockerImage = 'PUBLIC_DOCKER_IMAGE_GOES_HERE'
+        String embeddingCreationDockerImage = 'PUBLIC_DOCKER_IMAGE_WILL_GO_HERE'
         Int embeddingCreationCPU = 8
         Int embeddingCreationMemoryGB = 30
         Int embeddingCreationDiskGB = 10

--- a/single_plate_example_inputs.json
+++ b/single_plate_example_inputs.json
@@ -1,0 +1,10 @@
+{
+  "EmbeddingCreation.tfHubModelOutputEmbSize":"${1280}",
+  "EmbeddingCreation.cellCentersPathPrefix":"s3://cellpainting-gallery/cpg0016-jump/source_10/workspace/analysis/2021_05_31_U2OS_48_hr_run1/Dest210531-152149/analysis",
+  "EmbeddingCreation.cellPatchDim":"${128}",
+  "EmbeddingCreation.loadDataWithIllum":"s3://cellpainting-gallery/cpg0016-jump/source_10/workspace/load_data_csv/2021_05_31_U2OS_48_hr_run1/Dest210531-152149/load_data_with_illum.parquet",
+  "EmbeddingCreation.tfHubModelInputImageHeight":"${384}",
+  "EmbeddingCreation.tfHubModelPath":"https://tfhub.dev/google/imagenet/efficientnet_v2_imagenet21k_s/feature_vector/2",
+  "EmbeddingCreation.tfHubModelInputImageWidth":"${384}",
+  "EmbeddingCreation.modelBatchDim":"${256}"
+}


### PR DESCRIPTION
Also added an example set of inputs for display on Dockstore. 

Tested all of this in the deflaux GitHub org.
* https://github.com/deflaux?tab=packages 
* https://dockstore.org/workflows/github.com/deflaux/embedder:nd_test_dockstore?tab=files 
